### PR TITLE
delete -modern tag

### DIFF
--- a/beacon-chain/Dockerfile
+++ b/beacon-chain/Dockerfile
@@ -1,5 +1,5 @@
 ARG UPSTREAM_VERSION
-FROM sigp/lighthouse:${UPSTREAM_VERSION}-modern
+FROM sigp/lighthouse:${UPSTREAM_VERSION}
 
 COPY entrypoint.sh entrypoint.sh
 COPY jwtsecret.hex /jwtsecret

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -1,5 +1,5 @@
 ARG UPSTREAM_VERSION
-FROM sigp/lighthouse:${UPSTREAM_VERSION}-modern
+FROM sigp/lighthouse:${UPSTREAM_VERSION}
 
 # Copy token
 COPY security/api-token.txt /root/.lighthouse/validators/


### PR DESCRIPTION
no longer maintained. See "Breaking Changes" of 5.3.0 lighthouse release:
https://github.com/sigp/lighthouse/releases/tag/v5.3.0

